### PR TITLE
Implement folder-first storage with alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ desktop devices.
   blood pressure and heart rate.  Charts can be downloaded as PNG images.
 - **Offline capable** – a service worker caches the HTML, CSS, JS and icons so
   the app continues to run without a network connection.
+- **On-device storage** – choose a folder and the app will keep a JSON file with
+  your medications and logs. This folder is the primary location. If it can't be
+  used later, the app falls back to browser storage and alerts you.
 
 ## Running locally
 
@@ -31,6 +34,14 @@ Then navigate to `http://localhost:8000`.
 
 On mobile devices you can choose "Add to Home Screen" to install the app like a
 native application.
+
+### Backup folder
+
+In the **Setup Rx** tab you can press **Choose Backup Folder** to select a
+directory on your device. A JSON file named `rxtracker-data.json` will be kept in
+that folder with all medications and logs. If the folder becomes unavailable or
+the File System Access API isn't supported, the app will switch to browser
+storage and show an alert.
 
 ## License
 

--- a/app.js
+++ b/app.js
@@ -16,15 +16,136 @@ const downloadHrBtn = document.getElementById('download-hr');
 const navButtons = document.querySelectorAll('#bottom-nav button');
 const medSubmitBtn = medForm.querySelector('button[type="submit"]');
 const editVitalsBtn = document.getElementById('edit-vitals');
+const chooseFolderBtn = document.getElementById('choose-folder');
+const folderDisplay = document.getElementById('folder-display');
 let editingMedId = null;
 
 // LocalStorage Helpers
 function getMeds() { return JSON.parse(localStorage.getItem('meds') || '[]'); }
-function saveMeds(meds) { localStorage.setItem('meds', JSON.stringify(meds)); }
+function saveMeds(meds) {
+  localStorage.setItem('meds', JSON.stringify(meds));
+  backupData();
+}
 function getMedLogs() { return JSON.parse(localStorage.getItem('medLogs') || '{}'); }
-function saveMedLogs(logs) { localStorage.setItem('medLogs', JSON.stringify(logs)); }
+function saveMedLogs(logs) {
+  localStorage.setItem('medLogs', JSON.stringify(logs));
+  backupData();
+}
 function getVitalsLogs() { return JSON.parse(localStorage.getItem('vitalsLogs') || '{}'); }
-function saveVitalsLogs(logs) { localStorage.setItem('vitalsLogs', JSON.stringify(logs)); }
+function saveVitalsLogs(logs) {
+  localStorage.setItem('vitalsLogs', JSON.stringify(logs));
+  backupData();
+}
+
+// --- File System Access API Backup ---
+let folderHandle = null;
+let fallbackAlertShown = false;
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open('rx-tracker', 1);
+    request.onupgradeneeded = e => {
+      e.target.result.createObjectStore('handles');
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function saveDirHandle(handle) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction('handles', 'readwrite');
+    tx.objectStore('handles').put(handle, 'dir');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function loadDirHandle() {
+  const db = await openDB();
+  return new Promise(resolve => {
+    const tx = db.transaction('handles', 'readonly');
+    const req = tx.objectStore('handles').get('dir');
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+  });
+}
+
+async function clearDirHandle() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction('handles', 'readwrite');
+    tx.objectStore('handles').delete('dir');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function backupData() {
+  if (!folderHandle) return;
+  try {
+    const fileHandle = await folderHandle.getFileHandle('rxtracker-data.json', { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(JSON.stringify({
+      meds: getMeds(),
+      medLogs: getMedLogs(),
+      vitalsLogs: getVitalsLogs()
+    }, null, 2));
+    await writable.close();
+  } catch (err) {
+    console.error('Failed to backup data', err);
+    if (!fallbackAlertShown) {
+      alert('Lost access to the chosen folder. Using local storage instead.');
+      fallbackAlertShown = true;
+    }
+    folderHandle = null;
+    folderDisplay.textContent = '';
+    clearDirHandle();
+  }
+}
+
+async function restoreFromFile() {
+  if (!folderHandle) return;
+  try {
+    const fileHandle = await folderHandle.getFileHandle('rxtracker-data.json');
+    const file = await fileHandle.getFile();
+    const data = JSON.parse(await file.text());
+    if (data.meds) saveMeds(data.meds);
+    if (data.medLogs) saveMedLogs(data.medLogs);
+    if (data.vitalsLogs) saveVitalsLogs(data.vitalsLogs);
+  } catch (err) {
+    if (!fallbackAlertShown) {
+      alert('Could not read data from the chosen folder. Using local storage instead.');
+      fallbackAlertShown = true;
+    }
+    folderHandle = null;
+    folderDisplay.textContent = '';
+    clearDirHandle();
+  }
+}
+
+async function chooseFolder() {
+  if (!window.showDirectoryPicker) {
+    alert('File System Access API not supported. Using local storage only.');
+    return;
+  }
+  try {
+    const handle = await window.showDirectoryPicker();
+    const perm = await handle.requestPermission({ mode: 'readwrite' });
+    if (perm === 'granted') {
+      folderHandle = handle;
+      folderDisplay.textContent = handle.name;
+      await saveDirHandle(handle);
+      await backupData();
+      fallbackAlertShown = false;
+    }
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+chooseFolderBtn.addEventListener('click', chooseFolder);
 
 // Utility to return today's date in the user's local timezone
 function getTodayString() {
@@ -328,7 +449,26 @@ downloadHrBtn.addEventListener('click', () => {
 });
 
 // Initialize app
-function init() {
+async function init() {
+  const storedHandle = await loadDirHandle();
+  if (storedHandle && !window.showDirectoryPicker) {
+    alert('File System Access API not available. Using local storage instead.');
+  }
+  if (storedHandle && window.showDirectoryPicker) {
+    folderHandle = storedHandle;
+    let perm = await folderHandle.queryPermission({ mode: 'readwrite' });
+    if (perm === 'prompt') {
+      perm = await folderHandle.requestPermission({ mode: 'readwrite' });
+    }
+    if (perm === 'granted') {
+      folderDisplay.textContent = folderHandle.name;
+      await restoreFromFile();
+    } else {
+      alert('Could not access the chosen folder. Using local storage instead.');
+      folderHandle = null;
+      folderDisplay.textContent = '';
+    }
+  }
   renderMeds();
   renderLog();
   renderVitals();

--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
       <button type="submit">Save Medication</button>
     </form>
     <ul id="med-list"></ul>
+    <div id="fs-setup">
+      <button type="button" id="choose-folder">Choose Backup Folder</button>
+      <span id="folder-display"></span>
+    </div>
   </section>
 
   <section id="today-log">

--- a/style.css
+++ b/style.css
@@ -126,3 +126,12 @@ th, td {
   padding: 0.25rem;
   text-align: center;
 }
+
+#fs-setup {
+  margin-top: 1rem;
+}
+
+#folder-display {
+  margin-left: 0.5rem;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
- emphasize folder as primary storage in README
- alert user and revert to local storage if folder access fails
- keep folder name and clear handle when losing access

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687fd06f11e88331b72f24ad3f0259ba