### PR TITLE
Add automatic JSON export for data

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ desktop devices.
   blood pressure and heart rate.  Charts can be downloaded as PNG images.
 - **Offline capable** – a service worker caches the HTML, CSS, JS and icons so
   the app continues to run without a network connection.
+- **Automatic JSON backups** – whenever data is saved, a JSON snapshot of all
+  stored information is downloaded so you can keep your own copy.
 
 ## Running locally
 

--- a/app.js
+++ b/app.js
@@ -20,11 +20,41 @@ let editingMedId = null;
 
 // LocalStorage Helpers
 function getMeds() { return JSON.parse(localStorage.getItem('meds') || '[]'); }
-function saveMeds(meds) { localStorage.setItem('meds', JSON.stringify(meds)); }
+function saveMeds(meds) {
+  localStorage.setItem('meds', JSON.stringify(meds));
+  exportAllData();
+}
 function getMedLogs() { return JSON.parse(localStorage.getItem('medLogs') || '{}'); }
-function saveMedLogs(logs) { localStorage.setItem('medLogs', JSON.stringify(logs)); }
+function saveMedLogs(logs) {
+  localStorage.setItem('medLogs', JSON.stringify(logs));
+  exportAllData();
+}
 function getVitalsLogs() { return JSON.parse(localStorage.getItem('vitalsLogs') || '{}'); }
-function saveVitalsLogs(logs) { localStorage.setItem('vitalsLogs', JSON.stringify(logs)); }
+function saveVitalsLogs(logs) {
+  localStorage.setItem('vitalsLogs', JSON.stringify(logs));
+  exportAllData();
+}
+
+function exportAllData() {
+  const data = {
+    meds: getMeds(),
+    medLogs: getMedLogs(),
+    vitalsLogs: getVitalsLogs()
+  };
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: 'application/json'
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  a.href = url;
+  a.download = `rx-tracker-backup-${ts}.json`;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
 
 // Utility to return today's date in the user's local timezone
 function getTodayString() {


### PR DESCRIPTION
## Summary
- automatically trigger an export of all stored data whenever meds, medication logs or vitals are saved
- document the new backup feature in the README

## Testing
- `node -e "require('./app.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68819b208ee483318d3c9c347a363108