### PR TITLE
Add CSV export for vital charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ desktop devices.
 - **Vitals recording** – capture systolic and diastolic blood pressure and heart
   rate each day.
 - **History tracker** – view past medication logs and simple line charts for
-  blood pressure and heart rate.  Charts can be downloaded as PNG images.
+  blood pressure and heart rate. Charts can be downloaded as PNG images, and
+  readings can be exported as CSV files.
 - **Offline capable** – a service worker caches the HTML, CSS, JS and icons so
   the app continues to run without a network connection.
 - **Automatic JSON backups** – whenever data is saved, a JSON snapshot of all

--- a/app.js
+++ b/app.js
@@ -13,6 +13,8 @@ const bpCanvas = document.getElementById('bp-chart');
 const hrCanvas = document.getElementById('hr-chart');
 const downloadBpBtn = document.getElementById('download-bp');
 const downloadHrBtn = document.getElementById('download-hr');
+const exportBpCsvBtn = document.getElementById('export-bp-csv');
+const exportHrCsvBtn = document.getElementById('export-hr-csv');
 const navButtons = document.querySelectorAll('#bottom-nav button');
 const medSubmitBtn = medForm.querySelector('button[type="submit"]');
 const editVitalsBtn = document.getElementById('edit-vitals');
@@ -367,6 +369,40 @@ downloadHrBtn.addEventListener('click', () => {
   a.href = url;
   a.download = 'heart_rate.png';
   a.click();
+});
+
+exportBpCsvBtn.addEventListener('click', () => {
+  const logs = getVitalsLogs();
+  const dates = Object.keys(logs).sort();
+  let csv = 'Date,Systolic,Diastolic\n';
+  dates.forEach(date => {
+    const v = logs[date];
+    csv += `${date},${v.systolic},${v.diastolic}\n`;
+  });
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'blood_pressure.csv';
+  a.click();
+  URL.revokeObjectURL(url);
+});
+
+exportHrCsvBtn.addEventListener('click', () => {
+  const logs = getVitalsLogs();
+  const dates = Object.keys(logs).sort();
+  let csv = 'Date,Heart Rate\n';
+  dates.forEach(date => {
+    const v = logs[date];
+    csv += `${date},${v.heartRate}\n`;
+  });
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'heart_rate.csv';
+  a.click();
+  URL.revokeObjectURL(url);
 });
 
 importFileInput.addEventListener('change', e => {

--- a/index.html
+++ b/index.html
@@ -59,10 +59,12 @@
     <h3>Blood Pressure</h3>
     <canvas id="bp-chart" width="300" height="150"></canvas>
     <button id="download-bp">Download PNG</button>
+    <button id="export-bp-csv">Export CSV</button>
 <br><br>
     <h3>Heart Rate</h3>
     <canvas id="hr-chart" width="300" height="150"></canvas>
     <button id="download-hr">Download PNG</button>
+    <button id="export-hr-csv">Export CSV</button>
   </section>
 
   <nav id="bottom-nav">


### PR DESCRIPTION
## Summary
- add buttons to export blood pressure and heart rate readings to CSV
- implement CSV generation and download logic
- document CSV export in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e19e215008331ae24e004f972c910